### PR TITLE
Fix undefined fsync, access, R_OK, unlink, and getcwd

### DIFF
--- a/htslib/cram/cram_io.c
+++ b/htslib/cram/cram_io.c
@@ -53,6 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include <zlib.h>
 #ifdef HAVE_LIBBZ2
 #include <bzlib.h>


### PR DESCRIPTION
by including `unistd.h`. Fixed upstream in https://github.com/samtools/htslib/commit/0ec5202de5691b27917ce828a9d24c9c729a9b81

I've only see this on the OS X image used by Starforge, perhaps due to the version of XCode (and thus the compiler) installed. But regardless, this allows the wheel to build (the current wheels on wheels.galaxyproject.org I built by hand on my laptop).
